### PR TITLE
Blazor api caching endless loop fixes

### DIFF
--- a/UI/SciMaterials.UI.BWASM/Pages/files/FIlesUploadHistory.razor
+++ b/UI/SciMaterials.UI.BWASM/Pages/files/FIlesUploadHistory.razor
@@ -1,7 +1,7 @@
 ﻿@page "/files_upload_history"
 
-@using SciMaterials.UI.BWASM.States.FilesUploadHistory.Behavior
 @using SciMaterials.UI.BWASM.States.FilesUploadHistory
+
 @inherits FluxorComponent
 
 @inject IDispatcher Dispatcher

--- a/UI/SciMaterials.UI.BWASM/States/Authors/AuthorsActions.cs
+++ b/UI/SciMaterials.UI.BWASM/States/Authors/AuthorsActions.cs
@@ -10,7 +10,7 @@ public static class AuthorsActions
     public record struct LoadAuthorsResultAction(ImmutableArray<AuthorState> Authors);
 
     public static LoadAuthorsAction LoadAuthors() => new();
-    public static LoadAuthorsAction ForceReloadAuthors() => new();
-    public static LoadAuthorsAction LoadAuthorsStart() => new();
+    public static ForceReloadAuthorsAction ForceReloadAuthors() => new();
+    public static LoadAuthorsStartAction LoadAuthorsStart() => new();
     public static LoadAuthorsResultAction LoadAuthorsResult(ImmutableArray<AuthorState> authors) => new(authors);
 }

--- a/UI/SciMaterials.UI.BWASM/States/Categories/Behavior/FilesCategoriesEffects.cs
+++ b/UI/SciMaterials.UI.BWASM/States/Categories/Behavior/FilesCategoriesEffects.cs
@@ -25,7 +25,7 @@ public class FilesCategoriesEffects
         await ForceReloadCategories(dispatcher);
     }
 
-    [EffectMethod(typeof(FilesCategoriesActions.LoadCategoriesAction))]
+    [EffectMethod(typeof(FilesCategoriesActions.ForceReloadCategoriesAction))]
     public async Task ForceReloadCategories(IDispatcher dispatcher)
     {
         dispatcher.Dispatch(FilesCategoriesActions.LoadCategoriesStart());

--- a/UI/SciMaterials.UI.BWASM/States/Categories/FilesCategoriesActions.cs
+++ b/UI/SciMaterials.UI.BWASM/States/Categories/FilesCategoriesActions.cs
@@ -12,7 +12,7 @@ public static class FilesCategoriesActions
 
     public static BuildTreeResultAction BuildTreeResult(HashSet<TreeFileCategory> tree) => new(tree);
     public static LoadCategoriesAction LoadCategories() => new();
-    public static LoadCategoriesAction ForceReloadCategories() => new();
-    public static LoadCategoriesAction LoadCategoriesStart() => new();
+    public static ForceReloadCategoriesAction ForceReloadCategories() => new();
+    public static LoadCategoriesStartAction LoadCategoriesStart() => new();
     public static LoadCategoriesResultAction LoadCategoriesResult(ImmutableArray<FileCategory> categories) => new(categories);
 }

--- a/UI/SciMaterials.UI.BWASM/States/ContentTypes/FilesContentTypesFilterActions.cs
+++ b/UI/SciMaterials.UI.BWASM/States/ContentTypes/FilesContentTypesFilterActions.cs
@@ -11,8 +11,8 @@ public static class FilesContentTypesFilterActions
     public record struct UpdateContentTypesFilterAction(ImmutableArray<ContentTypeState> Selected);
 
     public static LoadContentTypesAction LoadContentTypes() => new();
-    public static LoadContentTypesAction ForceReloadContentTypes() => new();
-    public static LoadContentTypesAction LoadContentTypesStart() => new();
+    public static ForceReloadContentTypesAction ForceReloadContentTypes() => new();
+    public static LoadContentTypesStartAction LoadContentTypesStart() => new();
     public static LoadContentTypesResultAction LoadContentTypesResult(ImmutableArray<ContentTypeState> contentTypes) => new(contentTypes);
     public static UpdateContentTypesFilterAction UpdateFilter(ImmutableArray<ContentTypeState> selected) => new(selected);
 }

--- a/UI/SciMaterials.UI.BWASM/States/FilesUploadHistory/FilesUploadHistoryState.cs
+++ b/UI/SciMaterials.UI.BWASM/States/FilesUploadHistory/FilesUploadHistoryState.cs
@@ -2,7 +2,7 @@
 
 using Fluxor;
 
-namespace SciMaterials.UI.BWASM.States.FilesUploadHistory.Behavior;
+namespace SciMaterials.UI.BWASM.States.FilesUploadHistory;
 
 [FeatureState]
 public record FilesUploadHistoryState(ImmutableArray<FileUploadState> Files)


### PR DESCRIPTION
fix endless access loop by calling fluxor states actions for content types, authors and categories